### PR TITLE
Fix: issue with api_key in webhook

### DIFF
--- a/notifiers/webhook.go
+++ b/notifiers/webhook.go
@@ -130,8 +130,8 @@ func (w *webhooker) run(body string) (*http.Response, error) {
 			req.Header.Add(split[0], split[1])
 		}
 	}
-	if w.ApiSecret != "" {
-		req.Header.Add("Content-Type", w.ApiSecret)
+	if w.ApiKey != "" {
+		req.Header.Add("Content-Type", w.ApiKey)
 	}
 	resp, err := client.Do(req)
 	if err != nil {

--- a/notifiers/webhook_test.go
+++ b/notifiers/webhook_test.go
@@ -25,6 +25,7 @@ import (
 var (
 	WEBHOOK_URL    = "https://jsonplaceholder.typicode.com/posts"
 	webhookMessage = `{ "title": "%service.Id", "body": "%service.Name", "online": %service.Online, "userId": 19999 }`
+  apiKey = "application/json"
 	fullMsg        string
 )
 
@@ -41,10 +42,12 @@ func TestWebhookNotifier(t *testing.T) {
 	t.Run("Load webhooker", func(t *testing.T) {
 		webhook.Host = WEBHOOK_URL
 		webhook.Delay = time.Duration(100 * time.Millisecond)
+    webhook.ApiKey = apiKey
 		err := notifier.AddNotifier(webhook)
 		assert.Nil(t, err)
 		assert.Equal(t, "Hunter Long", webhook.Author)
 		assert.Equal(t, WEBHOOK_URL, webhook.Host)
+    assert.Equal(t, apiKey, webhook.ApiKey)
 	})
 
 	t.Run("Load webhooker Notifier", func(t *testing.T) {


### PR DESCRIPTION
Fixed issue where api_key value, aka content type field in Webhook UI
  - Webhook is setting ApiSecret value into Content-Type header